### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent guidance – wp-module-features
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-features** – Provides an interface for feature flags/toggles in Newfold WordPress brand plugins. Features are registered via the `newfold/features/filter/register` filter; the module stores enabled state in the options table (`newfold_features`) and exposes it to the admin app and via REST API and CLI. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. Uses `wp-forge/wp-options` for persistence. No frontend UI in this repo; host apps consume the REST API and `isEnabled()` helper.
+
+- **Architecture:** Singleton `Features::getInstance()` initializes a `Registry` and hooks into `plugins_loaded`, `rest_api_init`, `cli_init`, and `admin_enqueue_scripts`. Features are registered by other modules via the filter; the module provides REST routes under `newfold-features/v1` and a CLI command.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Entry / singleton | `includes/Features.php` – `getInstance()`, init, filters |
+| Registry & options | `includes/Registry.php` – feature instances and `newfold_features` option |
+| Feature model | `includes/Feature.php` |
+| REST API | `includes/FeaturesAPI.php` – namespace `newfold-features/v1` |
+| CLI | `includes/FeaturesCLI.php` |
+| Helpers | `includes/functions.php` – `isEnabled()`, `enable()`, `disable()` |
+| Tests | `tests/` (Codeception wpunit) |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+composer run test-coverage
+composer run i18n-pot   # and i18n, i18n-json, etc.
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+**When you change code, features, or workflows, update the docs so they stay accurate.**
+
+- Keep all docs current, not only the ones listed here.
+- When adding or changing REST routes, update **docs/api.md**. When adding or changing dependencies, update **dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ composer run i18n-pot   # and i18n, i18n-json, etc.
 
 ## Keeping documentation current
 
-**When you change code, features, or workflows, update the docs so they stay accurate.**
+**When you change code, features, or workflows, update the docs so they stay accurate.** Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present).
 
 - Keep all docs current, not only the ones listed here.
 - When adding or changing REST routes, update **docs/api.md**. When adding or changing dependencies, update **dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,18 @@
+# REST API
+
+The module registers REST routes under the **`newfold-features/v1`** namespace. All routes require permission (typically `manage_options`). Base URL: `{site}/wp-json/newfold-features/v1`.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/newfold-features/v1/features` | List all registered features and their enabled state. |
+| POST | `/newfold-features/v1/feature/enable` | Enable a feature. Body: `{ "feature": "feature-name" }`. |
+| POST | `/newfold-features/v1/feature/disable` | Disable a feature. Body: `{ "feature": "feature-name" }`. |
+
+## Response
+
+- **GET /features** – Returns an array of feature objects (name, enabled, and any other fields the feature exposes).
+- **POST /feature/enable** and **/feature/disable** – Return the updated feature or an error if the feature name is invalid or not found.
+
+Permission callback is defined in `FeaturesAPI::checkPermission()` (typically requires `manage_options`).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: REST API
+description: REST API or public API reference.
+updated: 2025-03-18
+---
+
 # REST API
 
 The module registers REST routes under the **`newfold-features/v1`** namespace. All routes require permission (typically `manage_options`). Base URL: `{site}/wp-json/newfold-features/v1`.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 ## Runtime

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,19 @@
+# Dependencies
+
+## Runtime
+
+| Package | Purpose |
+|---------|---------|
+| **wp-forge/wp-options** | Persistent key-value storage for feature enabled state. The module uses an `Options` instance with the key `newfold_features`; the registry reads/writes via the options object. |
+
+## Runtime expectations
+
+- The module uses `NewfoldLabs\WP\ModuleLoader\container()` to get the plugin instance (e.g. `container()->plugin()->url`). The host must have set the container via the loader before features are initialized (e.g. on `plugins_loaded`).
+
+## Dev
+
+- **johnpbloch/wordpress** – WordPress core for WPUnit tests.
+- **lucatume/wp-browser** – Codeception and WPUnit.
+- **newfold-labs/wp-php-standards** – PHPCS rules.
+- **phpunit/phpcov** – Coverage.
+- **wp-cli/i18n-command** – i18n pot/po/mo/json generation.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Linting

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,21 @@
+# Development
+
+## Linting
+
+- **PHP:** `composer run lint` (PHPCS), `composer run fix` (PHPCBF). Uses `phpcs.xml` and `newfold-labs/wp-php-standards`.
+
+## Testing
+
+- **WPUnit (Codeception):** `composer run test` runs the `wpunit` suite.
+- **Coverage:** `composer run test-coverage`; then open `tests/_output/html/index.html`.
+
+## i18n
+
+- Text domain: **wp-module-features**. Use `composer run i18n-pot` and `composer run i18n` (or the individual i18n-* scripts). Language files live in `languages/`.
+
+## Day-to-day workflow
+
+1. Make changes in `includes/` or add new feature classes.
+2. Run `composer run lint` and `composer run test` before committing.
+3. When adding or changing REST routes, update [api.md](api.md). When adding or changing the register filter or feature API, update [integration.md](integration.md) and [overview.md](overview.md).
+4. When cutting a release, update **docs/changelog.md** with the version and changes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,55 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.3+ (see `composer.json` platform).
+- **Composer** for dependencies.
+- **WordPress** (for running the module; tests use johnpbloch/wordpress as dev dependency).
+
+## Install
+
+From the package root:
+
+```bash
+composer install
+```
+
+This pulls in `wp-forge/wp-options` and dev dependencies (WordPress, Codeception, PHPCS, etc.).
+
+## Run tests
+
+```bash
+composer run test
+```
+
+Uses Codeception with the `wpunit` suite. For coverage:
+
+```bash
+composer run test-coverage
+```
+
+Then open `tests/_output/html/index.html` to view the report.
+
+## Lint and fix
+
+```bash
+composer run lint
+composer run fix
+```
+
+## i18n
+
+```bash
+composer run i18n-pot    # generate .pot
+composer run i18n        # full pipeline (pot, po, mo, php, json)
+```
+
+Text domain: **wp-module-features**. Language files live in `languages/`.
+
+## Using in a host plugin
+
+1. Depend on `newfold-labs/wp-module-features` via Composer.
+2. Register features on the `newfold/features/filter/register` filter (pass an array of feature class names that extend `NewfoldLabs\WP\Module\Features\Feature`).
+3. Use `NewfoldLabs\WP\Module\Features\isEnabled( 'feature-name' )` to gate behavior. The admin app can call the REST API to list and toggle features.
+
+See [integration.md](integration.md) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-features – Documentation index
 
 Documentation for wp-module-features, for **humans** and **AI agents**. Start here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# wp-module-features – Documentation index
+
+Documentation for wp-module-features, for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does, who maintains it, and high-level behavior. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and how to run tests. |
+| [integration.md](integration.md) | How to register features and use the filter/API. |
+| [api.md](api.md) | REST API endpoints and request/response. |
+| [development.md](development.md) | Lint, test, i18n, and day-to-day workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies and how they are used. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Registering or checking features:** [integration.md](integration.md).
+- **REST API:** [api.md](api.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,30 @@
+# Integration
+
+## Registering features
+
+Other modules or the host plugin register features by adding to the `newfold/features/filter/register` filter. The value is an array of class names; each class must extend `NewfoldLabs\WP\Module\Features\Feature` and will be instantiated with the module’s options object. The feature’s `getName()` is used as the key in the registry.
+
+Example:
+
+```php
+add_filter( 'newfold/features/filter/register', function ( $features ) {
+    $features[] = MyFeature::class;
+    return $features;
+} );
+```
+
+Each feature class extends `Feature`, implements `getName()`, and can override default enabled state and behavior. State is persisted in the option `newfold_features` (keyed by feature name).
+
+## Checking and toggling
+
+- **PHP:** `isEnabled( $name )`, `enable( $name )`, `disable( $name )` (in namespace `NewfoldLabs\WP\Module\Features`). `isEnabled` returns a boolean or `WP_Error` if the feature is not found.
+- **REST:** GET `/newfold-features/v1/features` to list; POST to `/newfold-features/v1/feature/enable` or `.../feature/disable` with body `{ "feature": "name" }`. See [api.md](api.md).
+- **CLI:** WP-CLI commands are registered on `cli_init`; see the FeaturesCLI class for command names and args.
+
+## Filter: isEnabled
+
+The filter `newfold/features/filter/isEnabled` runs when resolving whether a feature is enabled. The module adds a default handler at priority 99 so that any feature not explicitly set returns false. Other code can use this filter to override or provide defaults.
+
+## Container
+
+The module uses `NewfoldLabs\WP\ModuleLoader\container()` to get the plugin instance (e.g. for asset URLs). It does not register itself with the loader; it is loaded by the host and other modules register features that may depend on container data.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## Registering features

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+# Overview
+
+## What the module does
+
+**wp-module-features** provides feature flags for Newfold WordPress brand plugins. Other modules and the host register features via a filter; this module stores each feature’s enabled/disabled state in the WordPress options table and exposes it via:
+
+- **PHP helpers:** `isEnabled( $name )`, `enable( $name )`, `disable( $name )`
+- **REST API:** GET list of features, POST to enable/disable (see [api.md](api.md))
+- **CLI:** WP-CLI commands for listing and toggling features
+- **Filter:** `newfold/features/filter/isEnabled` to override or default unknown features
+
+The admin app and other modules use these to gate UI and behavior by feature.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis and used by all Newfold WordPress brand plugins.
+
+## High-level features
+
+- Registry of feature instances (each extends `Feature`, has name and enabled state).
+- Persistence via `WP_Forge\Options\Options` (option name `newfold_features`).
+- REST namespace `newfold-features/v1` and WP-CLI integration.
+- i18n (text domain `wp-module-features`, languages in `languages/`).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-features
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)